### PR TITLE
adding selection color

### DIFF
--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -14,6 +14,11 @@ body {
   height: 100%;
 }
 
+::selection {
+  background: #222222;
+  color: #fff;
+}
+
 a {
   color: #9b9b9b;
   text-decoration: none;


### PR DESCRIPTION
Trying out some issues labelled as `good first issue`, so feel free to provide feedback! 

Sticking with the black and white theme of the site, I went with an inverse selection color: 
![image](https://user-images.githubusercontent.com/2169390/148664541-ae8e753c-48b2-4422-b379-c379763f3024.png)
